### PR TITLE
Fix typo, guard renderer writes, doc comment update, add grid tests

### DIFF
--- a/crates/splix_pane/src/grid.rs
+++ b/crates/splix_pane/src/grid.rs
@@ -24,3 +24,31 @@ impl Grid {
         &self.data
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Grid;
+
+    #[test]
+    fn new_grid_is_empty() {
+        let grid = Grid::new();
+        assert!(grid.get_data().is_empty());
+    }
+
+    #[test]
+    fn update_appends_chars() {
+        let mut grid = Grid::new();
+        grid.update('a');
+        grid.update('b');
+        assert_eq!(grid.get_data(), &vec![vec!['a', 'b']]);
+    }
+
+    #[test]
+    fn new_line_creates_new_empty_line() {
+        let mut grid = Grid::new();
+        grid.update('a');
+        grid.new_line();
+        grid.update('b');
+        assert_eq!(grid.get_data(), &vec![vec!['a'], vec!['b']]);
+    }
+}

--- a/crates/splix_renderer/src/lib.rs
+++ b/crates/splix_renderer/src/lib.rs
@@ -22,7 +22,7 @@ impl Renderer {
     pub fn begin_frame(&mut self) {
         self.reset_cursor();
 
-        // TODO: Should be probably removed later.
+        // TODO: Should probably be removed later.
         self.reset_render_buffer();
     }
 
@@ -82,6 +82,10 @@ impl Renderer {
             }
 
             for (x, character) in line.iter().enumerate() {
+                if (x as u32) >= self.screen_dimensions.x {
+                    break;
+                }
+
                 let index = self.render_buffer_index_from_position(UVec2::new(x as u32, y as u32));
                 self.render_buffer[index] = *character;
             }

--- a/crates/splix_termios/src/alternate_screen.rs
+++ b/crates/splix_termios/src/alternate_screen.rs
@@ -14,7 +14,7 @@ impl AlternateScreen {
     pub fn new() -> splix_error::Result<Self> {
         let ansi_encoder = AnsiEncoder::new();
 
-        // TODO: Handle cases where stdin is not a TTY.
+        // TODO: Handle cases where stdout is not a TTY.
         let mut tty = io::stdout();
         tty.write_all(ansi_encoder.encode(ENTER_ANSI_ESCAPE_CODE).as_bytes())
             .map_err(splix_error::Error::EnterAlternateTerminalScreen)?;


### PR DESCRIPTION
## Summary
- fix typo in renderer frame comment
- prevent out-of-bounds writes when drawing panes
- correct stdout reference in alternate screen
- add unit tests for `Grid`

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68424f25d0c4832cb1705600a75d520a